### PR TITLE
show SyntaxError detail

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,8 +73,87 @@ function adjustFilepath (filepath, sourceRoot) {
     return relativePath;
 }
 
+function syntaxErrorLine(lineNumber, maxLineNumberLength, line) {
+    var content = ['    '];
+    var lineNumberString = String(lineNumber);
+    for (var i = lineNumberString.length; i < maxLineNumberLength; i++) {
+        content.push(' ');
+    }
+    content.push(lineNumberString, ': ', line);
+    return content.join('');
+}
+
+function showSyntaxErrorDetail(code, error, filepath) {
+    var i;
+    var begin = code.lastIndexOf('\n', error.pos);
+    var end = code.indexOf('\n', error.pos);
+    if (end === -1) {
+        end = undefined;
+    }
+    var line = code.slice(begin + 1, end);
+    var beforeLines = [];
+    for (i = 0; i < 5; i++) {
+        if (begin === -1) {
+            break;
+        }
+        var lastBegin = begin;
+        begin = code.lastIndexOf('\n', begin - 1);
+        beforeLines.unshift(code.slice(begin + 1, lastBegin));
+        if (begin === 0) {
+            break;
+        }
+    }
+    var afterLines = [];
+    for (i = 0; i < 5; i++) {
+        if (end === undefined) {
+            break;
+        }
+        var lastEnd = end;
+        end = code.indexOf('\n', end + 1);
+        if (end === -1) {
+            end = undefined;
+        }
+        afterLines.push(code.slice(lastEnd + 1, end));
+    }
+
+    var lines = [''];
+    var numberLength = String(error.loc.line + afterLines.length).length;
+    for (i = 0; i < beforeLines.length; i++) {
+        lines.push(
+            syntaxErrorLine(error.loc.line - beforeLines.length + i, numberLength, beforeLines[i])
+        );
+    }
+    lines.push(syntaxErrorLine(error.loc.line, numberLength, line));
+    var lineContent = [];
+    for (i = 0; i < 6 + numberLength + error.loc.column - 1; i++) {
+       lineContent.push(' ');
+    }
+    lineContent.push('^');
+    lines.push(lineContent.join(''));
+    for (i = 0; i < afterLines.length; i++) {
+        lines.push(
+            syntaxErrorLine(error.loc.line + i + 1, numberLength, afterLines[i])
+        );
+    }
+    lines.push('', 'Parse Error: ' + error.message + (filepath ? ' in ' + filepath : ''));
+    var detail = lines.join('\n');
+    var err = new SyntaxError(detail);
+    err.loc = error.loc;
+    err.pos = error.pos;
+    err.raisedAt = error.pos;
+    throw err;
+}
+
 function instrument (originalCode, filepath, options) {
-    var jsAst = acorn.parse(originalCode, {locations: true, ecmaVersion:7, plugins: {asyncawait: true}});
+    var jsAst;
+    try {
+        jsAst = acorn.parse(originalCode, {locations: true, ecmaVersion:7, plugins: {asyncawait: true}});
+    } catch (e) {
+        if (e instanceof SyntaxError && e.pos && e.loc) {
+            showSyntaxErrorDetail(originalCode, e, filepath);
+        }
+        throw e;
+    }
     var modifiedAst = espower(jsAst, options);
     var escodegenOptions = extend({
         sourceMap: adjustFilepath(filepath || options.path, options.sourceRoot),
@@ -85,7 +164,15 @@ function instrument (originalCode, filepath, options) {
 }
 
 function instrumentWithoutSourceMapOutput (originalCode, options) {
-    var jsAst = acorn.parse(originalCode, {locations: true, ecmaVersion:7, plugins: {asyncawait: true}});
+    var jsAst;
+    try {
+        jsAst = acorn.parse(originalCode, {locations: true, ecmaVersion:7, plugins: {asyncawait: true}});
+    } catch (e) {
+        if (e instanceof SyntaxError && e.pos && e.loc) {
+            showSyntaxErrorDetail(originalCode, e);
+        }
+        throw e;
+    }
     var modifiedAst = espower(jsAst, options);
     return escodegen.generate(modifiedAst);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -384,3 +384,35 @@ describe('empty and blank files', function() {
         assert.equal(output, '\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IiIsInNvdXJjZXNDb250ZW50IjpbXX0=\n');
     });
 });
+
+describe('syntax error handling', function() {
+    var source = [
+        "var a = 1;",
+        "var b = 2;",
+        "var c = 3;",
+        "", // test empty line
+        "var e = 5;",
+        "var f = 6;",
+        "syntax error at line 7",
+        "var g = 8;",
+        "var h = 9;",
+        "var i = 10;",
+        "var j = 11;",
+        "var k = 12;",
+        "var l = 13;"].join('\n');
+
+    it('can generate SyntaxError with custom message with 10 lines surrounding the line', function() {
+        var error;
+        try {
+            espowerSource(source, "dummy.js");
+        } catch(e) {
+            error = e;
+        }
+        assert(error instanceof SyntaxError);
+        assert.notEqual(error.message.indexOf('     2: var b = 2;'), -1);
+        assert.notEqual(error.message.indexOf('     4: '), -1);
+        assert.notEqual(error.message.indexOf('     7: syntax error at line 7'), -1);
+        assert.notEqual(error.message.indexOf('       ^'), -1);
+        assert.notEqual(error.message.indexOf('    12: var k = 12;'), -1);
+    });
+});


### PR DESCRIPTION
espower-source is not friendly because it hides detail of SyntaxError. This patch shows lines surrounding an error position.

before:

```
/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:943
  var err = new SyntaxError(message);
            ^
SyntaxError: Unexpected token (71:18)
    at Parser.pp.raise (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:943:13)
    at Parser.pp.unexpected (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:1503:8)
    at Parser.pp.semicolon (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:1482:73)
    at Parser.pp.parseExpressionStatement (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:1972:8)
    at Parser.pp.parseStatement (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:1751:188)
    at Parser.parseStatement (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/acorn-es7-plugin/acorn-v3.js:105:25)
    at Parser.pp.parseBlock (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:1987:21)
    at Parser.pp.parseFunctionBody (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:603:22)
    at Parser.pp.parseArrowExpression (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:584:8)
    at Parser.pp.parseParenArrowList (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:416:15)
    at Parser.pp.parseParenAndDistinguishExpression (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:384:19)
    at Parser.pp.parseExprAtom (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:297:19)
    at Parser.parseExprAtom (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/acorn-es7-plugin/acorn-v3.js:125:30)
    at Parser.pp.parseExprSubscripts (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:216:19)
    at Parser.pp.parseMaybeUnary (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:197:19)
    at Parser.pp.parseExprOps (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:151:19)
    at Parser.pp.parseMaybeConditional (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:133:19)
    at Parser.pp.parseMaybeAssign (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:110:19)
    at Parser.pp.parseExprList (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:651:185)
    at Parser.pp.parseSubscripts (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:240:29)
    at Parser.pp.parseExprSubscripts (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:219:15)
    at Parser.pp.parseMaybeUnary (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:197:19)
    at Parser.pp.parseExprOps (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:151:19)
    at Parser.pp.parseMaybeConditional (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:133:19)
    at Parser.pp.parseMaybeAssign (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:110:19)
    at Parser.pp.parseExpression (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:86:19)
    at Parser.pp.parseStatement (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:1750:23)
    at Parser.parseStatement (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/acorn-es7-plugin/acorn-v3.js:105:25)
    at Parser.pp.parseTopLevel (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:1666:21)
    at Parser.parse (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:1636:17)
    at Object.parse (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/node_modules/acorn/dist/acorn.js:905:44)
    at instrument (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/index.js:83:23)
    at espowerSource (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/index.js:122:24)
    at Object.extensions..js (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-loader/index.js:42:22)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.require (module.js:483:17)
    at require (internal/module.js:20:19)
    at /Users/shibukawa.yoshiki/develop/i18n4v/node_modules/mocha/lib/mocha.js:222:27
    at Array.forEach (native)
    at Mocha.loadFiles (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/mocha/lib/mocha.js:219:14)
    at Mocha.run (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/mocha/lib/mocha.js:487:10)
    at Object.<anonymous> (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/mocha/bin/_mocha:458:18)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.runMain (module.js:590:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
```

after:

```
    58:             assert(words.contexts()[0].valueKeys().length === loadedWords.contexts()[0].valueKeys().length);
    59:         });
    60:     });
    61: });
    62: 
    63: Friendship is magic!
                  ^
    64: 
    65: describe('append value to data', () => {
    66:     const sourceJSON = `
    67:     {
    68:         "values": {

Parse Error: Unexpected token (63:11) in /Users/shibukawa.yoshiki/develop/i18n4v/test/test_data.js
    at showSyntaxErrorDetail (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/index.js:137:15)
    at instrument (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/index.js:150:13)
    at espowerSource (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-source/index.js:194:24)
    at Object.extensions..js (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/espower-loader/index.js:42:22)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.require (module.js:483:17)
    at require (internal/module.js:20:19)
    at /Users/shibukawa.yoshiki/develop/i18n4v/node_modules/mocha/lib/mocha.js:222:27
    at Array.forEach (native)
    at Mocha.loadFiles (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/mocha/lib/mocha.js:219:14)
    at Mocha.run (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/mocha/lib/mocha.js:487:10)
    at Object.<anonymous> (/Users/shibukawa.yoshiki/develop/i18n4v/node_modules/mocha/bin/_mocha:458:18)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.runMain (module.js:590:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
```